### PR TITLE
fix: remove unnecessary characters in Community Inspirations 

### DIFF
--- a/docs/guides/community-inspirations.md
+++ b/docs/guides/community-inspirations.md
@@ -14,7 +14,7 @@ head:
 This page is a tribute to our Community who have been using WebContainers over the past two years - and who have been building with WebContainer API since it was released in June 2022 in a private alpha. Here are some of the projects that are powered by it.
 
 ::: tip Get your project featured!
-Have a project you'd like us to showcase here and on our social media? Reach out to our [Developer Advocates on Discord](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
+Have a project you'd like us to showcase here and on our social media? Reach out to our [Developer Advocates](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
 :::
 
 ## Projects built with WebContainers

--- a/docs/guides/community-inspirations.md
+++ b/docs/guides/community-inspirations.md
@@ -70,5 +70,5 @@ Tech Educator's Toolkit is an early exploration of WebContainer API and of a new
 [![A still from Dan Jutan's talk](/img/community/dan_jutan_talk.png)](https://www.youtube.com/watch?v=R-1y3Ti3ng4)
 
 ::: tip Get your project featured!
-Have a project you'd like us to showcase here and on our social media? Reach out to our [Developer Advocates on Discord](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
+Have a project you'd like us to showcase here and on our social media? Reach out to our [Developer Advocates](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
 :::

--- a/docs/guides/community-inspirations.md
+++ b/docs/guides/community-inspirations.md
@@ -14,7 +14,7 @@ head:
 This page is a tribute to our Community who have been using WebContainers over the past two years - and who have been building with WebContainer API since it was released in June 2022 in a private alpha. Here are some of the projects that are powered by it.
 
 ::: tip Get your project featured!
-Have a project you'd like us to showcase here and on our social media? [Reach out to our [Developer Advocates on Discord](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
+Have a project you'd like us to showcase here and on our social media? Reach out to our [Developer Advocates on Discord](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
 :::
 
 ## Projects built with WebContainers
@@ -53,7 +53,7 @@ A command line chess game written in Node.js. [Explore it yourself!](https://git
 
 [![Command line chess game](/img/community/chess.png)](https://www.npmjs.com/package/schachnovelle)
 
-As [Manus Nijhoff](https://manusnijhoff.nl/), the author of this chess game, puts it, "“If you've got nothing better to do than waste time in the terminal, Stackblitz is there with you!”
+As [Manus Nijhoff](https://manusnijhoff.nl/), the author of this chess game, puts it, “If you've got nothing better to do than waste time in the terminal, Stackblitz is there with you!”
 
 ### Low-Code: Web Publisher
 
@@ -70,5 +70,5 @@ Tech Educator's Toolkit is an early exploration of WebContainer API and of a new
 [![A still from Dan Jutan's talk](/img/community/dan_jutan_talk.png)](https://www.youtube.com/watch?v=R-1y3Ti3ng4)
 
 ::: tip Get your project featured!
-Have a project you'd like us to showcase here and on our social media? [Reach out to our [Developer Advocates on Discord](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
+Have a project you'd like us to showcase here and on our social media? Reach out to our [Developer Advocates on Discord](https://github.com/stackblitz/webcontainer-docs/issues/new?assignees=sylwiavargas&labels=documentation&template=%E2%9C%A8-feature-your-project.md&title=%5B%E2%9C%A8+Project+submission%5D)!
 :::


### PR DESCRIPTION
Removed unnecessary `[` and `"` 📝

<a href="https://stackblitz.com/~/github.com/stackblitz/webcontainer-docs/tree/web-publisher/ykmsd/community-inspirations"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Web Publisher](https://developer.stackblitz.com/codeflow/integrating-web-publisher)._