### PR TITLE
Fix heading typo for "Running Processes" page

### DIFF
--- a/docs/guides/running-processes.md
+++ b/docs/guides/running-processes.md
@@ -1,11 +1,11 @@
 ---
-title: &title Running Proceses
+title: &title Running Processes
 head:
   - ['meta', {property: 'og:title', content: *title}]
   - ['meta', {property: 'og:image', content: 'https://webcontainers.io/img/og/guide-running_commands.png'}]
   - ['meta', {name: 'twitter:title', content: *title}]
 ---
-# Running Proceses
+# Running Processes
 
 This page covers executing commands inside WebContainers.
 


### PR DESCRIPTION


<a href="https://stackblitz.com/~/github.com/stackblitz/webcontainer-docs/tree/web-publisher/EricSimons/running-processes"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Web Publisher](https://developer.stackblitz.com/codeflow/integrating-web-publisher)._