### PR TITLE
feat: allow overriding the user-agent check

### DIFF
--- a/docs/.vitepress/theme/components/Examples/WCEmbed/utils.ts
+++ b/docs/.vitepress/theme/components/Examples/WCEmbed/utils.ts
@@ -6,7 +6,16 @@ export function isWebContainerSupported() {
   const looksLikeChrome = navigator.userAgent.toLowerCase().includes('chrome');
   const looksLikeFirefox = navigator.userAgent.includes('Firefox');
 
-  return hasSharedArrayBuffer && (looksLikeChrome || looksLikeFirefox);
+  if (hasSharedArrayBuffer && (looksLikeChrome || looksLikeFirefox)) {
+    return true;
+  }
+
+  // Allow overriding the support check with localStorage.webcontainer_any_ua = 1
+  try {
+    return Boolean(localStorage.getItem('webcontainer_any_ua'));
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
This PR adds the ability to bypass the feature and user-agent check in the `isWebContainerSupported` function, by adding any non-empty value for the `webcontainer_any_ua` key in localStorage.

This is intended to allow testing of browsers that we have excluded because they currently do not run WebContainers at all (Safari 16.3 and earlier releases), upcoming versions of those browser (Safari 16.4 Beta and later releases), and other web browsers which happen to run afoul of our simple UA checks for other reasons.

Steps for testing:

1. Use a browser such as Safari.
2. Go to https://webcontainers.io (or, when testing, a Netlify preview deploy for this PR).
3. Open the browser console and run `localStorage.webcontainer_any_ua = 1`.
4. Reload the page.

Expected result:

- We should not show the "Incompatible Web Browser" message (screenshot attached) in the demo terminal.
- What we actually see will depend on what the browser is actually able to run. The terminal may remain blank.

Screenshot of the current "Incompatible web browser" warning, for context:

![Screenshot](https://user-images.githubusercontent.com/243601/220099200-f1b6ac9f-7f91-4b47-bf95-baae73b8480b.png)

