### PR TITLE
feat(tutorial): add steps for attaching a terminal

### DIFF
--- a/docs/data.ts
+++ b/docs/data.ts
@@ -16,6 +16,8 @@ export const tutorialLinks = [
   { text: '3. Installing dependencies', link: '/tutorial/3-installing-dependencies' },
   { text: '4. Running dev server', link: '/tutorial/4-running-dev-server' },
   { text: '5. Editing & saving a file', link: '/tutorial/5-editing-a-file-updating-the-iframe' },
+  { text: '6. Connect a terminal', link: '/tutorial/6-connect-a-terminal' },
+  { text: '7. Make terminal interactive', link: '/tutorial/7-make-terminal-interactive' },
 ];
 
 export const homeExternalLinks = [

--- a/docs/tutorial/5-editing-a-file-updating-the-iframe.md
+++ b/docs/tutorial/5-editing-a-file-updating-the-iframe.md
@@ -47,4 +47,4 @@ And voilà! We have a working editor with the Preview. You've built your own env
 
 ## Next steps
 
-If you'd like to explore the API on your own, you can check out the [API reference](../api) or see the [projects made by our Community](/guides/community-inspirations).
+Our application is now entirely up and running. However, because we have built an application to write a simple Express.js application, it would be nice if we could see the output of all our commands inside our application instead of inside the DevTools console. [In the next step](./6-connect-a-terminal.md), you'll attach a terminal to the WebContainer processes to show the output.

--- a/docs/tutorial/6-connect-a-terminal.md
+++ b/docs/tutorial/6-connect-a-terminal.md
@@ -1,0 +1,181 @@
+---
+title: &title Connect a terminal
+description: &description Your Express is up and running and the Preview window reflects the changes made through the `textarea`. Let's add a terminal to show the output of our running processes.
+head:
+  - ['meta', {property: 'og:title', content: *title}]
+  - ['meta', {property: 'og:image', content: 'https://webcontainers.io/img/og/tutorial-5_editing_a_file_updating_the_iframe.png'}]
+  - ['meta', {name: 'twitter:title', content: *title}]
+  - ['meta', {name: 'twitter:description', content: *description}]
+---
+# Connecting a terminal
+
+Your Express app is up and running and the preview updates automatically when making changes through the `textarea`. However, opening the DevTools to see the WebContainers output is a bit annoying. So let's add a terminal which shows the output.
+
+## 1. Install Xterm.js
+
+We could print the output of our processes to a simple `div`. The problem is that a process could also print messages with different colors or styles. In order to achieve this, we will use [xterm.js](https://xtermjs.org). Install it by running the following command.
+
+```
+npm install xterm
+```
+
+## 2. Create the terminal
+
+In order to show the terminal in our application, we need to add an additional HTML element which we can then use to render the terminal. Open the `main.js` file, scroll to the bottom and add a new `div` which we can use as a parent element for our terminal.
+
+```js {10}
+document.querySelector('#app').innerHTML = `
+  <div class="container">
+    <div class="editor">
+      <textarea>I am a textarea</textarea>
+    </div>
+    <div class="preview">
+      <iframe src="loading.html"></iframe>
+    </div>
+  </div>
+  <div class="terminal"></div>
+`;
+```
+
+We also need to be able to reference the HTML element. In the same way as we reference our `textarea` and `iframe`, we can add the following line at the bottom of the `main.js` file.
+
+```js
+/** @type {HTMLTextAreaElement | null} */
+const terminalEl = document.querySelector('.terminal');
+```
+
+Now that we added the DOM node which we can use to render the terminal, we can create a terminal instance and render it.
+
+First of all we need to import Xterm.js. Add the import at the top of the `main.js` file.
+
+```js
+import { Terminal } from 'xterm'
+```
+
+Now we can create a new terminal and attach it to our `terminalEl` that we created before.
+
+```js {7-10}
+window.addEventListener('load', async () => {
+  textareaEl.value = files['index.js'].file.contents;
+  textareaEl.addEventListener('input', (e) => {
+    writeIndexJS(e.currentTarget.value);
+  });
+
+  const terminal = new Terminal({
+    convertEol: true,
+  });
+  terminal.open(terminalEl);
+
+  // Call only once
+  webcontainerInstance = await WebContainer.boot();
+  await webcontainerInstance.mount(files);
+
+  const exitCode = await installDependencies();
+  if (exitCode !== 0) {
+    throw new Error('Installation failed');
+  };
+
+  startDevServer();
+});
+```
+
+The reason we set `convertEol` to `true` is to force the cursor to always start at the beginning of the next line. If we don't enable this, the cursor will jump to the next line but does not jump to the start of the new line.
+
+You will notice that the terminal looks a bit weird. So let's fix that first! Xterm.js ships it's own CSS styles and can easily be imported at the top of our `main.js` file.
+
+```js
+import 'xterm/css/xterm.css';
+```
+
+TODO insert screenshot
+
+## 3. Send output to the terminal
+
+Now that our terminal is entirely setup, we can start redirecting the output of the WebContainer processes to that terminal instead of writing it to the DevTools console.
+
+To do that, we need to get hold of the `terminal` instance inside the `installDependencies` and `startDevServer` methods. We can do this by simply passing `terminal` as an argument to those methods.
+
+```js {16,21}
+window.addEventListener('load', async () => {
+  textareaEl.value = files['index.js'].file.contents;
+  textareaEl.addEventListener('input', (e) => {
+    writeIndexJS(e.currentTarget.value);
+  });
+
+  const terminal = new Terminal({
+    convertEol: true,
+  });
+  terminal.open(terminalEl);
+
+  // Call only once
+  webcontainerInstance = await WebContainer.boot();
+  await webcontainerInstance.mount(files);
+
+  const exitCode = await installDependencies(terminal);
+  if (exitCode !== 0) {
+    throw new Error('Installation failed');
+  };
+
+  startDevServer(terminal);
+});
+```
+
+Inside the `installDependencies` method, we now have a reference to the terminal instance. Instead of printing the data to the DevTools console, we can write it to the terminal instead.
+
+```js {4,9}
+/**
+ * @param {Terminal} terminal
+ */
+async function installDependencies(terminal) {
+  // Install dependencies
+  const installProcess = await webcontainerInstance.spawn('npm', ['install']);
+  installProcess.output.pipeTo(new WritableStream({
+    write(data) {
+      terminal.write(data);
+    }
+  }))
+  // Wait for install command to exit
+  return installProcess.exit;
+}
+```
+
+When you refresh the page, you will now see that the output of `npm install` is now shown in our the terminal we just created.
+
+TODO insert screenshot
+
+In order to show the output of the `npm run start` command, we can make identical changes for the `startDevServer` method.
+
+```js {4,10-16}
+/**
+ * @param {Terminal} terminal
+ */
+async function startDevServer(terminal) {
+  // Run `npm run start` to start the Express app
+  const serverProcess = await webcontainerInstance.spawn('npm', [
+    'run',
+    'start',
+  ]);
+  serverProcess.output.pipeTo(
+    new WritableStream({
+      write(data) {
+        terminal.write(data);
+      },
+    })
+  );
+
+  // Wait for `server-ready` event
+  webcontainerInstance.on('server-ready', (port, url) => {
+    iframeEl.src = url;
+  });
+}
+```
+
+Now that we made these changes, we not only see the output of the `npm install` command, but also from the `npm run start` command. When changing the code through the `textarea`, you will also see that the dev server restarts because of the changes you made.
+
+TODO insert screenshot
+
+## Next step
+
+The output is now visible in a terminal inside your web application. This improves the user experience because the user can now see what is going on and doesn't have to open the DevTools console anymore.
+
+The terminal is currently only a view for the output. [In the next step](./7-make-terminal-interactive.md), we'll make the terminal interactive allowing you to run your own commands from within your application.

--- a/docs/tutorial/7-make-terminal-interactive.md
+++ b/docs/tutorial/7-make-terminal-interactive.md
@@ -1,0 +1,255 @@
+---
+title: &title Make terminal interactive
+description: &description Your Express is up and running and we connected a terminal to the output of the WebContainer processes. Let's make the terminal more interactive allowing the user to run it's own commands.
+head:
+  - ['meta', {property: 'og:title', content: *title}]
+  - ['meta', {property: 'og:image', content: 'https://webcontainers.io/img/og/tutorial-5_editing_a_file_updating_the_iframe.png'}]
+  - ['meta', {name: 'twitter:title', content: *title}]
+  - ['meta', {name: 'twitter:description', content: *description}]
+---
+# Make terminal interactive
+
+The terminal that we setup in the previous step doesn't accept user input, it's currently just a view to see the logs with proper formatting. Wouldn't it be nice if we could convert this experience to a real terminal which allows you to install other packages, and run different commands? Let's get started!
+
+## 1. Remove code
+
+Isn't the best feeling as a developer that you can remove code which isn't necessary anymore? You can remove both the `installDependencies` and `startDevServer` methods. The only thing that we want to keep is listening for the `server-ready` event.
+
+```js {16-19}
+window.addEventListener('load', async () => {
+  textareaEl.value = files['index.js'].file.contents;
+  textareaEl.addEventListener('input', (e) => {
+    writeIndexJS(e.currentTarget.value);
+  });
+
+  const terminal = new Terminal({
+    convertEol: true,
+  });
+  terminal.open(terminalEl);
+
+  // Call only once
+  webcontainerInstance = await WebContainer.boot();
+  await webcontainerInstance.mount(files);
+
+  // Wait for `server-ready` event
+  webcontainerInstance.on('server-ready', (port, url) => {
+    iframeEl.src = url;
+  });
+});
+```
+
+Open the `loading.html` file and change the message.
+
+```html
+Use the terminal to run a command!
+```
+
+## 2. Start the shell
+
+In order to make the terminal a bit more usuable, instead of spawning commands separately, we could spawn `JSH` instead. 
+
+```js
+/**
+ * @param {Terminal} terminal
+ */
+async function startShell(terminal) {
+  const shellProcess = await webcontainerInstance.spawn('jsh');
+  shellProcess.output.pipeTo(
+    new WritableStream({
+      write(data) {
+        terminal.write(data);
+      },
+    })
+  );
+}
+```
+
+By connecting the output stream of our process to the Xterm.js terminal instance, we will see something that looks much more like a real interactive terminal you are familiar with. The only thing we still have to do is start the shell.
+
+```js {21}
+window.addEventListener('load', async () => {
+  textareaEl.value = files['index.js'].file.contents;
+  textareaEl.addEventListener('input', (e) => {
+    writeIndexJS(e.currentTarget.value);
+  });
+
+  const terminal = new Terminal({
+    convertEol: true,
+  });
+  terminal.open(terminalEl);
+
+  // Call only once
+  webcontainerInstance = await WebContainer.boot();
+  await webcontainerInstance.mount(files);
+
+  // Wait for `server-ready` event
+  webcontainerInstance.on('server-ready', (port, url) => {
+    iframeEl.src = url;
+  });
+
+  startShell(terminal);
+});
+```
+
+TODO add screenshot?
+
+## 3. Making the terminal interactive
+
+It's still not possible to actually do anything with the terminal. Currently, the terminal still only renders output, it does not yet accept input. Let's change that!
+
+Just like the [`output`](/api#▸-output-readablestream-string) property of the WebContainer process is a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream), the [`input`](/api#▸-input-writablestream-string) property of the process is a [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream). By writing data to the writable `input` stream, that data is sent to the WebContainer process.
+
+```js {11-14}
+async function startShell(terminal) {
+  const shellProcess = await webcontainerInstance.spawn('jsh');
+  shellProcess.output.pipeTo(
+    new WritableStream({
+      write(data) {
+        terminal.write(data);
+      },
+    })
+  );
+
+  const input = shellProcess.input.getWriter();
+  terminal.onData((data) => {
+    input.write(data);
+  });
+
+  return shellProcess;
+}
+```
+
+The first thing we do here is getting hold of a writer by using [`WritableStream.getWriter`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/getWriter). Calling this method will lock the input stream which means no one else could get another writer to that process. After we have our writer, we can listen for input received by the terminal. Every time you type a character in the terminal, the [`onData`](http://xtermjs.org/docs/api/terminal/classes/terminal/#ondata) handler is called. Inside that handler we can simply write the data to the `input` stream of our process.
+
+After this small change, we now entirely hooked up our terminal to the shell running in the WebContainer process. This means that we can now also send input to the process and run commands. You can now manually run `npm install && npm run start` or run any other command.
+
+TODO insert screenshot
+
+## 4. Window resizing
+
+You might've noticed that resizing the window doesn't redraw the terminal output. For instance, if you make the window very small, lines that are too long should wrap to the next line. In order to fix this, we have to make the WebContainer process aware of the size of the terminal.
+
+First of all, let's make sure that the terminal itself gets adjusted properly when resizing the window. For that, we can use the [xterm-addon-fit](http://xtermjs.org/docs/api/addons/fit/) plugin for Xterm.js which adjusts the terminal columns and rows depending on the element it's rendered in.
+
+Install the plugin first.
+
+```
+npm install xterm-addon-fit
+```
+
+And import it at the top of your `main.js` file.
+
+```js
+import { FitAddon } from 'xterm-addon-fit';
+```
+
+After we installed and imported the addon, we can create a new `FitAddon` instance and load it into the terminal.
+
+```js {7,12,15}
+window.addEventListener('load', async () => {
+  textareaEl.value = files['index.js'].file.contents;
+  textareaEl.addEventListener('input', (e) => {
+    writeIndexJS(e.currentTarget.value);
+  });
+
+  const fitAddon = new FitAddon();
+
+  const terminal = new Terminal({
+    convertEol: true,
+  });
+  terminal.loadAddon(fitAddon);
+  terminal.open(terminalEl);
+
+  fitAddon.fit();
+
+  // Call only once
+  webcontainerInstance = await WebContainer.boot();
+  await webcontainerInstance.mount(files);
+
+  // Wait for `server-ready` event
+  webcontainerInstance.on('server-ready', (port, url) => {
+    iframeEl.src = url;
+  });
+
+  startShell(terminal);
+});
+```
+
+We also call the `fit()` method on the addon immediately after attaching the terminal to the DOM to make sure that the terminal takes up the entire height and width of the `div` terminal element.
+
+The terminal itself now has the proper dimensions, but the WebContainer process that runs the shell is still not aware of what the exact dimensions are. To fix that, we can pass in the dimensions when spawning the WebContainer process.
+
+```js {3-6}
+async function startShell(terminal) {
+  const shellProcess = await webcontainerInstance.spawn('jsh', {
+    terminal: {
+      cols: terminal.cols,
+      rows: terminal.rows,
+    },
+  });
+  shellProcess.output.pipeTo(
+    new WritableStream({
+      write(data) {
+        terminal.write(data);
+      },
+    })
+  );
+
+  const input = shellProcess.input.getWriter();
+
+  terminal.onData((data) => {
+    input.write(data);
+  });
+}
+```
+
+When making the preview window very narrow and refreshing the page, you can now see that the text is properly wrapped to the width of the terminal.
+
+TODO Insert screenshot?
+
+The last problem we have to address is that if you now resize the window, the shell does not redraw the text to fit the new dimensions. In order to do that, we can use the [`resize`](/api#▸-resize) method on the WebContainer shell process.
+
+```js {26-32}
+window.addEventListener('load', async () => {
+  textareaEl.value = files['index.js'].file.contents;
+  textareaEl.addEventListener('input', (e) => {
+    writeIndexJS(e.currentTarget.value);
+  });
+
+  const fitAddon = new FitAddon();
+
+  const terminal = new Terminal({
+    convertEol: true,
+  });
+  terminal.loadAddon(fitAddon);
+  terminal.open(terminalEl);
+
+  fitAddon.fit();
+
+  // Call only once
+  webcontainerInstance = await WebContainer.boot();
+  await webcontainerInstance.mount(files);
+
+  // Wait for `server-ready` event
+  webcontainerInstance.on('server-ready', (port, url) => {
+    iframeEl.src = url;
+  });
+
+  const shellProcess = await startShell(terminal);
+  window.addEventListener('resize', () => {
+    fitAddon.fit();
+    shellProcess.resize({
+      cols: terminal.cols,
+      rows: terminal.rows,
+    });
+  });
+});
+```
+
+The last piece of code that we added first resizes the terminal element on our webpage. Because of this, the `cols` and `rows` of the Xterm.js `Terminal` instance are recalculated and updated. The only thing for us left to do is to notify the process that a resize event happened and we pass in the new dimensions of the terminal. This causes the process to redraw the screen.
+
+TODO attach animated screenshot?
+
+## Next steps
+
+If you'd like to explore the API on your own, you can check out the [API reference](../api) or see the [projects made by our Community](/guides/community-inspirations).


### PR DESCRIPTION
This PR adds 2 additional steps to the tutorial on how to attach a terminal to the WebContainer processes.

I have some inline `TODO` comments to add screenshots. I can add them myself, but then they might not be in the same style as the others.

I might also add some small questions and comments in the PR itself.