### PR TITLE
fix: navbar width inconsistency

### DIFF
--- a/docs/.vitepress/theme/styles/fixes.scss
+++ b/docs/.vitepress/theme/styles/fixes.scss
@@ -146,6 +146,11 @@
   display: none;
 }
 
+// Correct width on non-docs pages
+.VPNavBar .container {
+  max-width: unset;
+}
+
 // Semi-transparent background above content
 .VPNavBar .content-body {
   background-color: rgba(255,255,255,0.8) !important;


### PR DESCRIPTION
The top nav bar was sized inconsistently on docs and non-docs pages.

|Old|New|
|-|-|
|<img width="1584" alt="Screen Shot 2023-02-21 at 6 17 11 PM" src="https://user-images.githubusercontent.com/22125230/220495716-6ecffa0e-8174-42e7-a884-b1543650b953.png">|<img width="1589" alt="Screen Shot 2023-02-21 at 6 16 44 PM" src="https://user-images.githubusercontent.com/22125230/220495736-143cc48d-0bcb-4f73-a5c5-f871faff4eb4.png">|