### PR TITLE
chore: update/tighten custom-block elements

### DIFF
--- a/docs/.vitepress/theme/styles/content.scss
+++ b/docs/.vitepress/theme/styles/content.scss
@@ -5,7 +5,7 @@
 .vp-doc h2 {
   margin: 44px 0 24px;
   border-top: 1px solid var(--vp-c-divider-light);
-  padding-top: 32px;
+  padding-top: 24px;
 }
 
 // Wrap code examples

--- a/docs/.vitepress/theme/styles/fixes.scss
+++ b/docs/.vitepress/theme/styles/fixes.scss
@@ -101,28 +101,13 @@
   display: inline-block;
 }
 
-.vp-doc code {
+.vp-doc pre code {
   font-size: 12.5px !important;
 }
 
 .vp-code-group .tabs label {
   font-size: 13px !important;
   font-weight: 600;
-}
-
-.vp-doc .custom-block {
-  margin: 40px 0 !important;
-  padding: 16px 24px 16px;
-  @media (max-width: 500px) {
-    padding-left: 18px;
-    padding-right: 18px;
-  }
-}
-
-.vp-doc .custom-block p {
-  margin: 2px 0 0;
-  font-size: 14px;
-  line-height: 1.72;
 }
 
 .vp-doc div[class*='language-'] {
@@ -301,4 +286,123 @@
 .VPDocAside .outline-link {
   padding: 6px 0;
   font-size: 12.5px;
+}
+
+
+// --------------------------------
+// Custom Blocks
+
+.vp-doc .custom-block {
+  margin: 44px 0;
+  padding: 32px 32px;
+  padding-left: 72px;
+  border: none;
+  border-radius: 8px;
+  box-shadow:
+    inset 0 0 0 1px var(--block-border-color),
+    inset 40px 92px 64px -40px rgba(255,255,255,0.6);
+
+  @media (max-width: 500px) {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  &:not(:root.dark &) {
+    --vp-custom-block-tip-bg: rgb(246, 252, 250);
+    --vp-custom-block-tip-border: rgba(0, 136, 120, 0.5);
+    --vp-custom-block-tip-text: rgb(0, 125, 111);
+    --vp-custom-block-warning-text: rgb(202, 135, 0);
+    --vp-custom-block-warning-border: rgb(255, 200, 0);
+  }
+  :root.dark & {
+    --vp-custom-block-tip-text: hsl(165 100% 60%);
+    --vp-custom-block-tip-border: hsl(172, 100%, 19%);
+    --vp-custom-block-warning-text: rgb(255, 183, 0);
+    box-shadow:
+      inset 0 0 0 1px var(--block-border-color),
+      inset 40px 92px 84px -40px rgba(0,0,0,0.6);
+  }
+
+  &.info {
+    --block-border-color: var(--vp-custom-block-info-border);
+    --block-icon-color: var(--vp-custom-block-info-text);
+  }
+  &.tip {
+    --block-border-color: var(--vp-custom-block-tip-border);
+    --block-icon-color: var(--vp-custom-block-tip-text);
+  }
+  &.warning {
+    --block-border-color: var(--vp-custom-block-warning-border);
+    --block-icon-color: var(--vp-custom-block-warning-text);
+  }
+  &.danger {
+    --block-border-color: var(--vp-custom-block-danger-border);
+    --block-icon-color: var(--vp-custom-block-danger-text);
+  }
+  &.details {
+    --block-border-color: var(--vp-custom-block-details-border);
+    --block-icon-color: var(--vp-custom-block-details-text);
+  }
+}
+
+h2 + .custom-block {
+  margin-top: 32px !important;
+}
+
+.vp-doc h2 {
+  padding-top: 0;
+}
+
+.vp-doc .custom-block p {
+  margin: 2px 0 0;
+  font-size: 14px;
+  line-height: 1.8;
+  
+  &.custom-block-title {
+    position: relative;
+    margin-bottom: 8px;
+    @media (max-width: 500px) {
+      margin-left: 42px;
+      margin-bottom: 14px;
+    }
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -44px;
+      width: 24px;
+      height: 24px;
+      background-color: var(--block-icon-color);
+      -webkit-mask-image: url('/icons/fa-gear.svg');
+      mask-image: url('/icons/fa-gear.svg');
+      @media (max-width: 500px) {
+        left: -40px;
+      }
+    }
+  }
+}
+
+.vp-doc .custom-block p:not(.custom-block-title),
+.vp-doc .custom-block ol,
+.vp-doc .custom-block ul {
+  color: var(--vp-c-text-1);
+}
+.vp-doc .custom-block ol,
+.vp-doc .custom-block ul {
+  margin: 12px 0;
+}
+
+.vp-doc .custom-block a {
+  transition-duration: 0.1s;
+}
+
+.vp-doc .custom-block ul {
+  margin-bottom: 0;
+}
+
+.vp-doc .custom-block div[class*='language-'] {
+  margin: 24px 0;
+  &:last-child {
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
DX-34
"Community Tips" blocks needed a facelift, and by proxy, the rest of the `.custom-block` elements also got updated.
- More padding
- Colors brighter / less drab
- Different icons for each block

|Old|New|
|-|-|
|<img width="1687" alt="Screen Shot 2023-02-22 at 11 57 48 PM" src="https://user-images.githubusercontent.com/22125230/220839225-f7c1a2cf-bd16-4734-9176-2721110a2db8.png">|<img width="1685" alt="Screen Shot 2023-02-22 at 11 57 40 PM" src="https://user-images.githubusercontent.com/22125230/220839231-cb8901b1-de52-43a0-89cd-75dae2ea0bfd.png">|
|<img width="1684" alt="Screen Shot 2023-02-22 at 11 58 11 PM" src="https://user-images.githubusercontent.com/22125230/220839266-73c1c212-4e28-438f-b9ec-cb2f45e77227.png">|<img width="1682" alt="Screen Shot 2023-02-22 at 11 58 02 PM" src="https://user-images.githubusercontent.com/22125230/220839280-439bc683-a105-4e99-8146-6096ff3843d4.png">|
|<img width="1687" alt="Screen Shot 2023-02-22 at 11 56 56 PM" src="https://user-images.githubusercontent.com/22125230/220839059-c033006e-e180-42e3-91c9-87d233c2bc21.png">|<img width="1686" alt="Screen Shot 2023-02-22 at 11 56 49 PM" src="https://user-images.githubusercontent.com/22125230/220839075-c04eee5d-cbb8-46d0-960f-4a25b03bf564.png">|
|<img width="1683" alt="Screen Shot 2023-02-22 at 11 57 17 PM" src="https://user-images.githubusercontent.com/22125230/220839116-4df72d26-67e8-4ae9-8bec-f96d49b579ca.png">|<img width="1682" alt="Screen Shot 2023-02-22 at 11 57 08 PM" src="https://user-images.githubusercontent.com/22125230/220839137-e46134ab-a803-415a-9292-8a9fb66fa962.png">|


