### PR TITLE
Fix hydration issue on build

### DIFF
--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -8,7 +8,8 @@ export default {
   props: {},
   data() {
     return {
-      selectedCategories: {}
+      selectedCategories: {},
+      communityProjects: communityProjectCardData
     }
   },
   methods: {
@@ -44,7 +45,7 @@ export default {
   </div>
 
   <div class="community-projects">
-    <template v-for="(project, index) in communityProjectCardData">
+    <template v-for="(project, index) in communityProjects">
       <a v-if="!Object.keys(selectedCategories).length || Object.keys(selectedCategories).includes(project.category)"
         :key="index"
         class="project-item"

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -46,7 +46,7 @@ export default {
 
   <div class="community-projects" v-if="communityProjects">
     <template v-for="(project, index) in communityProjects">
-      <a v-if="Object.keys(selectedCategories).includes(project.category) || !Object.keys(selectedCategories).length"
+      <a v-if="Object.keys(selectedCategories).includes(project.category) || Object.keys(selectedCategories).length === 0"
         :key="index"
         class="project-item"
         :href="project.itemUrl"

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -44,10 +44,11 @@ export default {
   </div>
 
   <div class="community-projects">
-    <template v-for="project of communityProjectCardData">
+    <template v-for="(project, index) in communityProjectCardData">
     <a v-if="!Object.keys(selectedCategories).length || Object.keys(selectedCategories).includes(project.category)"
       class="project-item"
       :href="project.itemUrl"
+      :key="index"
     >
       <CardSingle>
         <div class="item-content">

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -9,7 +9,9 @@ export default {
   data() {
     return {
       selectedCategories: {},
-      communityProjects: communityProjectCardData ? communityProjectCardData : null
+      communityProjects: !Object.keys(this.selectedCategories).length
+        ? communityProjectCardData
+        : communityProjectCardData.filter(project => Object.keys(this.selectedCategories).includes(project.category))
     }
   },
   methods: {
@@ -44,10 +46,9 @@ export default {
     </button>
   </div>
 
-  <div class="community-projects" v-if="communityProjects">
-    <template v-for="(project, index) in communityProjects">
-      <a v-if="Object.keys(selectedCategories).includes(project.category) || Object.keys(selectedCategories).length === 0"
-        :key="index"
+  <div class="community-projects">
+    <template v-for="project in communityProjects">
+      <a
         class="project-item"
         :href="project.itemUrl"
       >

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -44,7 +44,7 @@ export default {
     </button>
   </div>
 
-  <div class="community-projects">
+  <div class="community-projects" v-if="communityProjects">
     <template v-for="(project, index) in communityProjects">
       <a v-if="!Object.keys(selectedCategories).length || Object.keys(selectedCategories).includes(project.category)"
         :key="index"

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -9,7 +9,7 @@ export default {
   data() {
     return {
       selectedCategories: {},
-      communityProjects: communityProjectCardData
+      communityProjects: communityProjectCardData ? communityProjectCardData : null
     }
   },
   methods: {

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -9,14 +9,13 @@ export default {
   data() {
     return {
       selectedCategories: {},
-      communityProjects: !Object.keys(this.selectedCategories).length
-        ? communityProjectCardData
-        : communityProjectCardData.filter(project => Object.keys(this.selectedCategories).includes(project.category))
+      communityProjects: communityProjectCardData
     }
   },
   methods: {
     clearSelectedCategories() {
       this.selectedCategories = {};
+      this.communityProjects = communityProjectCardData;
     },
     toggleSelectedCategory(category: CommunityProjectCategory) {
       if (this.selectedCategories[category]) {
@@ -25,6 +24,9 @@ export default {
       } else {
         this.selectedCategories[category] = true;
       }
+      this.communityProjects = Object.keys(this.selectedCategories).length === 0
+        ? communityProjectCardData
+        : communityProjectCardData.filter(project => Object.keys(this.selectedCategories).includes(project.category));
     }
   }
 }
@@ -47,28 +49,25 @@ export default {
   </div>
 
   <div class="community-projects">
-    <template v-for="project in communityProjects">
-      <a
-        class="project-item"
-        :href="project.itemUrl"
-      >
-        <CardSingle>
-          <div class="item-content">
-            <img :src="project.thumbnailUrl" />
+    <a v-for="project of communityProjects"
+      class="project-item"
+      :href="project.itemUrl"
+    >
+      <CardSingle>
+        <div class="item-content">
+          <img :src="project.thumbnailUrl" />
 
-            <div class="item-description">
-              <div class="description-heading">
-                <span class="project-title">{{ project.title }}</span>
-                <span class="project-title">{{ project.category }}</span>
-                <span class="project-category" :style="{'--category-rgb': categories[project.category].rgb}">{{ categories[project.category].title }}</span>
-              </div>
-              <p v-html="project.description" />
+          <div class="item-description">
+            <div class="description-heading">
+              <span class="project-title">{{ project.title }}</span>
+              <span class="project-category" :style="{'--category-rgb': categories[project.category].rgb}">{{ categories[project.category].title }}</span>
             </div>
-
+            <p v-html="project.description" />
           </div>
-        </CardSingle>
-      </a>
-    </template>
+
+        </div>
+      </CardSingle>
+    </a>
   </div>
 </template>
 

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -49,8 +49,7 @@ export default {
   </div>
 
   <div class="community-projects">
-    <a v-for="(project, index) of communityProjects"
-      :key="index"
+    <a v-for="project of communityProjects"
       class="project-item"
       :href="project.itemUrl"
     >

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -44,11 +44,10 @@ export default {
   </div>
 
   <div class="community-projects">
-    <template v-for="(project, index) in communityProjectCardData">
+    <template v-for="project of communityProjectCardData">
     <a v-if="!Object.keys(selectedCategories).length || Object.keys(selectedCategories).includes(project.category)"
       class="project-item"
       :href="project.itemUrl"
-      :key="index"
     >
       <CardSingle>
         <div class="item-content">

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -58,6 +58,7 @@ export default {
             <div class="item-description">
               <div class="description-heading">
                 <span class="project-title">{{ project.title }}</span>
+                <span class="project-title">{{ project.category }}</span>
                 <span class="project-category" :style="{'--category-rgb': categories[project.category].rgb}">{{ categories[project.category].title }}</span>
               </div>
               <p v-html="project.description" />

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -46,7 +46,7 @@ export default {
 
   <div class="community-projects" v-if="communityProjects">
     <template v-for="(project, index) in communityProjects">
-      <a v-if="!Object.keys(selectedCategories).length || Object.keys(selectedCategories).includes(project.category)"
+      <a v-if="Object.keys(selectedCategories).includes(project.category) || !Object.keys(selectedCategories).length"
         :key="index"
         class="project-item"
         :href="project.itemUrl"

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -63,7 +63,7 @@ export default {
               <span class="project-title">{{ project.title }}</span>
               <span class="project-category" :style="{'--category-rgb': categories[project.category].rgb}">{{ categories[project.category].title }}</span>
             </div>
-            <p v-html="project.description" />
+            <p>{{ project.description }}</p>
           </div>
 
         </div>

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -44,27 +44,28 @@ export default {
   </div>
 
   <div class="community-projects">
-    <template v-for="project of communityProjectCardData">
-    <a v-if="!Object.keys(selectedCategories).length || Object.keys(selectedCategories).includes(project.category)"
-      class="project-item"
-      :href="project.itemUrl"
-    >
-      <CardSingle>
-        <div class="item-content">
-          <img :src="project.thumbnailUrl" />
+    <template v-for="(project, index) in communityProjectCardData">
+      <a v-if="!Object.keys(selectedCategories).length || Object.keys(selectedCategories).includes(project.category)"
+        :key="index"
+        class="project-item"
+        :href="project.itemUrl"
+      >
+        <CardSingle>
+          <div class="item-content">
+            <img :src="project.thumbnailUrl" />
 
-          <div class="item-description">
-            <div class="description-heading">
-              <span class="project-title">{{ project.title }}</span>
-              <span class="project-category" :style="{'--category-rgb': categories[project.category].rgb}">{{ categories[project.category].title }}</span>
+            <div class="item-description">
+              <div class="description-heading">
+                <span class="project-title">{{ project.title }}</span>
+                <span class="project-category" :style="{'--category-rgb': categories[project.category].rgb}">{{ categories[project.category].title }}</span>
+              </div>
+              <p v-html="project.description" />
             </div>
-            <p v-html="project.description" />
-          </div>
 
-        </div>
-      </CardSingle>
-    </a>
-  </template>
+          </div>
+        </CardSingle>
+      </a>
+    </template>
   </div>
 </template>
 

--- a/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
+++ b/docs/.vitepress/theme/components/CommunityProjects/CommunityProjects.vue
@@ -49,7 +49,8 @@ export default {
   </div>
 
   <div class="community-projects">
-    <a v-for="project of communityProjects"
+    <a v-for="(project, index) of communityProjects"
+      :key="index"
       class="project-item"
       :href="project.itemUrl"
     >

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,9 @@
   [headers.values]
     Cross-Origin-Embedder-Policy = "require-corp"
     Cross-Origin-Opener-Policy = "same-origin"
+[build.processing.css]
+  minify = false
+[build.processing.js]
+  minify = false
 [build.processing.html]
   minify = false

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,5 @@
   [headers.values]
     Cross-Origin-Embedder-Policy = "require-corp"
     Cross-Origin-Opener-Policy = "same-origin"
+[build.processing.html]
+  minify = false

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,12 +3,3 @@
   [headers.values]
     Cross-Origin-Embedder-Policy = "require-corp"
     Cross-Origin-Opener-Policy = "same-origin"
-[build.processing.css]
-  minify = false
-[build.processing.js]
-  minify = false
-[build.processing.html]
-  minify = false
-# If skip_processing = true, all other settings are ignored
-[build.processing]
-  skip_processing = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,6 @@
   minify = false
 [build.processing.html]
   minify = false
+# If skip_processing = true, all other settings are ignored
+[build.processing]
+  skip_processing = true


### PR DESCRIPTION
So the culprit seemed to be a `v-html` inside a `v-for` which loops over unchanging data imported into the `.vue` component from a `.ts` object.

The bug does NOT exist locally however, only when deployed to Netlify.

Vitepress' docs say that hydration issues like this one can occur from the build process/tool Auto-Minifying the HTML, as Vue uses syntax like `<!------>` for placeholders which would obviously be "cleaned up" as benign comments by HTML minification.
https://vitepress.dev/guide/deploy#netlify-vercel-cloudflare-pages-aws-amplify-render
https://github.com/vuejs/vitepress/issues/369#issuecomment-1150970906

However, we don't have HTML minifying enabled on our Netlify build at all, which makes this even more curious:

![image](https://user-images.githubusercontent.com/22125230/227008196-b2055769-2a64-43de-9fd6-15c5bc606c51.png)

Regardless, changing the single `<p v-html="project.description" />` to `<p>{{ project.description }}</p>` fixed this hydration issue (and actually perhaps others(?)).
Note, not all `v-html` instances break this, but only `v-html` only in this scenario seems to break it.

I'm still quite confused, but overall it "makes sense" somewhere, and now we at least have a user-facing fix.

**Old:**

https://user-images.githubusercontent.com/22125230/227009784-6f62d5a1-8cff-48bb-9060-9ee1b66a3814.mov

  

**New:**

https://user-images.githubusercontent.com/22125230/227009881-ab3b5237-92e1-48ca-8d31-7cd7df041e53.mov

