### PR TITLE
chore(safari): enable terminal on Safari 16.4

### DIFF
--- a/docs/.vitepress/theme/components/Examples/WCEmbed/utils.ts
+++ b/docs/.vitepress/theme/components/Examples/WCEmbed/utils.ts
@@ -1,13 +1,23 @@
 /**
  * Checks if WebContainer is supported on the current browser.
  */
-export function isWebContainerSupported() {
+export function isWebContainerSupported() {  
   const hasSharedArrayBuffer = 'SharedArrayBuffer' in window;
   const looksLikeChrome = navigator.userAgent.toLowerCase().includes('chrome');
   const looksLikeFirefox = navigator.userAgent.includes('Firefox');
+  const looksLikeSafari = navigator.userAgent.includes('Safari');
 
   if (hasSharedArrayBuffer && (looksLikeChrome || looksLikeFirefox)) {
     return true;
+  }
+
+  if (hasSharedArrayBuffer && looksLikeSafari) {
+    // we only support Safari 16.4 and up so we check for the version here
+    const match = navigator.userAgent.match(/Version\/(\d+)\.(\d+) (?:Mobile\/.*?)?Safari/);
+    const majorVersion = match ? Number(match?.[1]) : 0;
+    const minorVersion = match ? Number(match?.[2]) : 0;
+
+    return majorVersion > 16 || (majorVersion === 16 && minorVersion >= 4);
   }
 
   // Allow overriding the support check with localStorage.webcontainer_any_ua = 1

--- a/docs/.vitepress/theme/components/Examples/WCEmbed/webcontainer.ts
+++ b/docs/.vitepress/theme/components/Examples/WCEmbed/webcontainer.ts
@@ -112,7 +112,7 @@ async function bootWebContainer(terminal: import('xterm').Terminal) {
         [
           red('Incompatible Web Browser'),
           '',
-          `WebContainers currently work in Chromium-based browsers and Firefox. We're hoping to add support for more browsers as they implement the necessary Web Platform features.`,
+          `WebContainers currently work in Chromium-based browsers, Firefox, and Safari 16.4. We're hoping to add support for more browsers as they implement the necessary Web Platform features.`,
           '',
           'Read more about browser support:',
           'https://webcontainers.io/guides/browser-support',


### PR DESCRIPTION
This PR will re-enable the terminal on Safari 16.4 and up.