### PR TITLE
Fix event name in Quickstart doc

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -100,7 +100,7 @@ async function startDevServer() {
 
 ## 4. Preview
 
-After you have started the dev server, get the URL from `port-ready` event and mount it in an iframe:
+After you have started the dev server, get the URL from `server-ready` event and mount it in an iframe:
 
 ```js
 webcontainerInstance.on('server-ready', (port, url) => (iframeEl.src = url));


### PR DESCRIPTION
Hey there.

As far as I understand, there is no event called `port-ready`, only [`server-ready`](https://webcontainers.io/api#%E2%96%B8-on). `server-ready` is also used in the code example below the text I edited.