### PR TITLE
fix: case studies link

### DIFF
--- a/docs/.vitepress/theme/data/links.ts
+++ b/docs/.vitepress/theme/data/links.ts
@@ -62,7 +62,7 @@ export const footerSections = [
       { text: 'Docs', link: 'https://developer.stackblitz.com/' },
       { text: 'Enterprise', link: 'https://stackblitz.com/enterprise' },
       { text: 'Pricing', link: 'https://stackblitz.com/membership' },
-      { text: 'Case Studies', link: 'https://stackblitz.com/case-studies/google' },
+      { text: 'Case Studies', link: 'https://stackblitz.com/case-studies' },
     ],
   },
   {


### PR DESCRIPTION
This fixes the case studies page to be the new one
-----
<a href="https://stackblitz.com/~/github/stackblitz/webcontainer-docs/tree/samdenty%2Ffix-case-studies"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/stackblitz/webcontainer-docs/tree/samdenty%2Ffix-case-studies)._