### PR TITLE
fix: isDark not firing

### DIFF
--- a/docs/.vitepress/theme/components/WCUsedByOrgs/WCUsedBy.vue
+++ b/docs/.vitepress/theme/components/WCUsedByOrgs/WCUsedBy.vue
@@ -6,11 +6,13 @@
 
 <template>
   <div class="used_by">
-    <img
+    <ClientOnly>
+      <img
       v-for="company of wcUsedBy"
       :src="isDark ? company.imgDark : company.imgLight"
       :alt="`${company.name} logo`"
-    />
+      />
+    </ClientOnly>
   </div>
 </template>
 

--- a/docs/.vitepress/theme/components/WCUsedByOrgs/WCUsedBy.vue
+++ b/docs/.vitepress/theme/components/WCUsedByOrgs/WCUsedBy.vue
@@ -8,9 +8,9 @@
   <div class="used_by">
     <ClientOnly>
       <img
-      v-for="company of wcUsedBy"
-      :src="isDark ? company.imgDark : company.imgLight"
-      :alt="`${company.name} logo`"
+        v-for="company of wcUsedBy"
+        :src="isDark ? company.imgDark : company.imgLight"
+        :alt="`${company.name} logo`"
       />
     </ClientOnly>
   </div>


### PR DESCRIPTION
Fixes DES-118

The `vitepress` `isDark` helper from its `useData()` hook is used in the `WCUsedBy` component, aka "corporate logos" section.
It fires correctly in development, but [not on production](https://github.com/vuejs/vitepress/issues/3267#issuecomment-1855006261), so `isDark` seemed to always default to `false`.

Fixed by wrapping `isDark` calls inside [`<ClientOnly>`](https://vite-plugin-ssr.com/client-only-components) wrappers.

|old|new|
|-|-|
|<img width="1566" alt="Screen Shot 2024-01-20 at 10 04 06 PM" src="https://github.com/stackblitz/webcontainer-docs/assets/22125230/47292175-ed9a-4a5c-a0e6-c6d078e689fe">|<img width="1571" alt="Screen Shot 2024-01-20 at 10 04 36 PM" src="https://github.com/stackblitz/webcontainer-docs/assets/22125230/56912e6d-55ab-47e2-a970-8ff635ab1907">|
