### PR TITLE
update auth links

### DIFF
--- a/docs/.vitepress/theme/components/AuthButtons/AuthButtons.vue
+++ b/docs/.vitepress/theme/components/AuthButtons/AuthButtons.vue
@@ -4,8 +4,8 @@ defineProps<{ place: 'navScreen' | 'navBar' }>();
 
 <template>
   <div :class="place === 'navScreen' ? 'navScreenContainer' : 'navBarContainer'">
-    <a href="https://stackblitz.com/sign_in" class="link light">Sign in</a>
-    <a href="https://stackblitz.com/register" class="link accent">Get started</a>
+    <a href="/enterprise" class="link light">Request a license</a>
+    <a href="/guides/quickstart" class="link accent">Get started</a>
   </div>
 </template>
 


### PR DESCRIPTION
Closes PRO-1918

> Link "Get started" to https://webcontainers.io/guides/quickstart to be consistent with the homepage
have a secondary CTA for "Request a license" and link to https://webcontainers.io/enterprise

![image](https://github.com/stackblitz/webcontainer-docs/assets/22125230/9d19d219-4a03-4093-b396-2dad5edb9129)
