### PR TITLE
docs: fix typos

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -610,7 +610,7 @@ const tree = {
           contents: 'const x = 1;',
         },
       },
-      .envrc: {
+      '.envrc': {
         file: {
           contents: 'ENVIRONMENT=staging'
         }

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -15,10 +15,10 @@ This page provides the bare-minimum overview on how to start building with WebCo
 We have prepared a [step-by-step walkthrough](../tutorial/1-build-your-first-webcontainer-app) for you!
 :::
 
-**The WebContainer API starter is the fastest way to explore the API**. Open it in StackBlitz editor:  
+**The WebContainer API starter is the fastest way to explore the API**. Open it in StackBlitz editor:
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://webcontainer.new)
 
-or in Codeflow IDE, our full-fledged web environment:  
+or in Codeflow IDE, our full-fledged web environment:
 [![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https:///pr.new/github.com/stackblitz/webcontainer-api-starter)
 
 If you prefer to develop locally, follow the steps below.
@@ -100,7 +100,7 @@ async function startDevServer() {
 
 ## 4. Preview
 
-After you have started the dev server, get the URL from `port-ready` event and mount it in an iframe:
+After you have started the dev server, get the URL from `server-ready` event and mount it in an iframe:
 
 ```js
 webcontainerInstance.on('server-ready', (port, url) => (iframeEl.src = url));

--- a/docs/guides/running-processes.md
+++ b/docs/guides/running-processes.md
@@ -52,7 +52,7 @@ Calling `spawn` returns a `WebContainerProcess`. Every process has an `output` p
 
 The output property is a `ReadableStream`. That’s because it is, in fact, a stream that can emit strings numerous times, just like the actual `stdout` or `stderr` from a process in Node.js. The advantage of streams is that they allow composition, meaning we can pipe data from one stream into another stream, for example `source.pipeTo(destination)`. Furthermore, streams can be transferred via `postMessage` from one context to a different context, for example a web worker. A `ReadableStream` also keeps a buffer of the data which is only flushed once you start reading.
 
-If you want to read data from output you can pipe it into a `WriteableStream` just like in the example above.
+If you want to read data from output you can pipe it into a `WriteableStream` just like in the example below.
 
 :::
 
@@ -61,7 +61,7 @@ An example of a usage could be the following:
 
 ```js
   const installProcess = await webcontainerInstance.spawn('npm', ['install']);
-  
+
   installProcess.output.pipeTo(new WritableStream({
     write(data) {
       console.log(data);


### PR DESCRIPTION
No related issues.

Hi, thank you for providing Stackblitz and related products.
I, as an OSS maintainer, heavily rely on your products.

Here is a PR to fix some typos and wording in WebContainers documentation.
(Some trailing spaces are removed as well)

⚠️ This is my very first PR for this repository, so I might be missing something important.