### PR TITLE
fix: reorganize top links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -90,8 +90,9 @@ export default defineConfig({
     nav: [
       { text: 'Guides', link: '/guides/introduction' },
       { text: 'Tutorial', link: '/tutorial/1-build-your-first-webcontainer-app' },
-      { text: 'Artificial Intelligence', link: '/ai' },
-      { text: 'Commercial Usage', link: '/enterprise' },
+      { text: 'API Reference', link: '/api' },
+      { text: 'AI', link: '/ai' },
+      { text: 'Pricing', link: '/enterprise' },
     ],
     sidebar: {
       '/guides/': SIDEBAR_DEFAULT,


### PR DESCRIPTION
- Add back in `API Reference`
- Make `Artificial Intelligence` and ` Commercial Usage` more succinct.

Old:

![image](https://github.com/stackblitz/webcontainer-docs/assets/22125230/906a0e9a-5af8-46e7-a694-9ef15530eaa9)

New:

![image](https://github.com/stackblitz/webcontainer-docs/assets/22125230/996c16f9-000e-4c6e-91c8-770c6945c1ca)

