### PR TITLE
chore: update docs to 1.5.0

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -355,7 +355,7 @@ To reload a preview you can use [`reloadPreview`](#reloadpreview)
 
 :::warning
 This API is an advanced feature that should only be used if it is your only option.
-As you can control what runs in webcontainer it's usually best to use your own server if you can.
+Since you can control servers running in WebContainer, it's preferable to add this code when serving the content itself.
 
 <br />
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,20 +346,20 @@ Returns a [`FileSystemTree`](#filesystemtree) when the format is `json`, otherwi
 Added in version `1.5.0`.
 
 Configure a script to be injected inside all previews. After this function returned,
-every preview iframes that are either added or reloaded will now include that extra
+every preview iframe that is either added or reloaded will now include this extra
 script on all HTML responses.
 
-Notably, existing previews won't included until they have been reloaded.
+Notably, existing previews won't include the script until they have been reloaded.
 
 To reload a preview you can use [`reloadPreview`](#reloadpreview)
 
 :::warning
-This API is a pretty advanced feature that should be used only if this is your only option.
+This API is an advanced feature that should only be used if it is your only option.
 As you can control what runs in webcontainer it's usually best to use your own server if you can.
 
 <br />
 
-In particular, this might break exisiting or future WebContainer features added in the future.
+In particular, this might break existing or future WebContainer features added in the future.
 :::
 
 <h4 id="wc-setpreviewscript-signature">
@@ -1148,7 +1148,7 @@ Globbing patterns to exclude files from the export.
 
 ## `PreviewScriptOptions`
 
-Options that control attributes on a script injected in previews.
+Options that control attributes on a script injected into previews.
 
 ```ts
 export interface PreviewScriptOptions {
@@ -1164,19 +1164,19 @@ export interface PreviewScriptOptions {
 
 #### ▸ `type?: 'module' | 'importmap'`
 
-The type attribute to use for the script. For more information, check the [MDN page on script: type attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type).
+The type attribute to use for the script. For more information, check the [MDN page on the script: type attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type).
 
 <br />
 
 #### ▸ `defer?: boolean`
 
-If set to true, then the `defer` attribute will be set on the script tag. For more information, check the [MDN page on script: defer attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async).
+If set to true, then the `defer` attribute will be set on the script tag. For more information, check the [MDN page on the script: defer attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async).
 
 <br />
 
 #### ▸ `async?: boolean`
 
-If set to true, then the `async` attribute will be set on the script tag. For more information, check the [MDN page on script: async attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async).
+If set to true, then the `async` attribute will be set on the script tag. For more information, check the [MDN page on the script: async attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async).
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -341,6 +341,49 @@ const zip = new Blob([data]);
 
 Returns a [`FileSystemTree`](#filesystemtree) when the format is `json`, otherwise a `Uint8Array`.
 
+### ▸ `setPreviewScript`
+
+Added in version `1.5.0`.
+
+Configure a script to be injected inside all previews. After this function returned,
+every preview iframes that are either added or reloaded will now include that extra
+script on all HTML responses.
+
+Notably, existing previews won't included until they have been reloaded.
+
+To reload a preview you can use [`reloadPreview`](#reloadpreview)
+
+:::warning
+This API is a pretty advanced feature that should be used only if this is your only option.
+As you can control what runs in webcontainer it's usually best to use your own server if you can.
+
+<br />
+
+In particular, this might break exisiting or future WebContainer features added in the future.
+:::
+
+<h4 id="wc-setpreviewscript-signature">
+  <a id="wc-setpreviewscript-signature">Signature</a>
+  <a href="#wc-setpreviewscript-signature" class="header-anchor" aria-hidden="true">#</a>
+</h4>
+
+<code>setPreviewScript(scriptSrc: string, options?: <a href="#previewscriptoptions">PreviewScriptOptions</a>): Promise&lt;void&gt;</code>
+
+<h4 id="wc-setpreviewscript-example">
+  <a id="wc-setpreviewscript-example">Example</a>
+  <a href="#wc-setpreviewscript-example" class="header-anchor" aria-hidden="true">#</a>
+</h4>
+
+```js
+const script = `
+  console.log('Hello world!');
+`;
+
+await webcontainerInstance.setPreviewScript(script);
+
+// now all previews will always print hello world to the console.
+```
+
 ### ▸ `teardown`
 
 Destroys the WebContainer instance, turning it unusable, and releases its resources. After this, a new WebContainer instance can be obtained by calling [`boot`](#▸-boot).
@@ -1100,6 +1143,40 @@ Globbing patterns to include files from within excluded folders.
 #### ▸ `excludes?: string[]`
 
 Globbing patterns to exclude files from the export.
+
+---
+
+## `PreviewScriptOptions`
+
+Options that control attributes on a script injected in previews.
+
+```ts
+export interface PreviewScriptOptions {
+  type?: 'module' | 'importmap';
+  defer?: boolean;
+  async?: boolean;
+}
+```
+
+### `PreviewScriptOptions` Properties
+
+<br />
+
+#### ▸ `type?: 'module' | 'importmap'`
+
+The type attribute to use for the script. For more information, check the [MDN page on script: type attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type).
+
+<br />
+
+#### ▸ `defer?: boolean`
+
+If set to true, then the `defer` attribute will be set on the script tag. For more information, check the [MDN page on script: defer attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async).
+
+<br />
+
+#### ▸ `async?: boolean`
+
+If set to true, then the `async` attribute will be set on the script tag. For more information, check the [MDN page on script: async attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async).
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -345,7 +345,7 @@ Returns a [`FileSystemTree`](#filesystemtree) when the format is `json`, otherwi
 
 Added in version `1.5.0`.
 
-Configure a script to be injected inside all previews. After this function returned,
+Configure a script to be injected inside all previews. After this function resolves,
 every preview iframe that is either added or reloaded will now include this extra
 script on all HTML responses.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ head:
 
 # Changelog
 
+## 1.5.0
+
+* Add support for injecting a script in previews with [`setPreviewScript`](api#▸-setPreviewScript).
+
 ## 1.4.0
 
 * Add support for exporting the file system with [`export`](api#▸-export).


### PR DESCRIPTION
This PR updates the docs to version 1.5.0 of `@webcontainer/api`.